### PR TITLE
Handle 0 lengths faithfully

### DIFF
--- a/buffercursor.js
+++ b/buffercursor.js
@@ -91,7 +91,7 @@ BufferCursor.prototype.tell = function() {
 BufferCursor.prototype.slice = function(length) {
   var end, b;
 
-  if (!length) {
+  if (length == undefined) {
     end = this.length;
   } else {
     end = this._pos + length;
@@ -106,7 +106,7 @@ BufferCursor.prototype.slice = function(length) {
 BufferCursor.prototype.toString = function(encoding, length) {
   var end, ret;
 
-  if (!length) {
+  if (length == undefined) {
     end = this.length;
   } else {
     end = this._pos + length;
@@ -132,7 +132,7 @@ BufferCursor.prototype.write = function(value, length, encoding) {
 BufferCursor.prototype.fill = function(value, length) {
   var end;
 
-  if (!length) {
+  if (length == undefined) {
     end = this.length;
   } else {
     end = this._pos + length;


### PR DESCRIPTION
The specific issue I'm running into here concerns BinaryPack and serializing zero-length strings.  Without this patch, BinaryPack fails during deserialization because it calls `cursor.toString('utf8',0)` and buffercursor interprets this as a request for the entire rest of the buffer.

Does this seem like a reasonable change, or should it be addressed within BinaryPack?

-Stefan
