### PR TITLE
changed version range of verror from ^ to ~

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "node": ">= 0.5.0"
   },
   "dependencies": {
-    "verror": "^1.4.0"
+    "verror": "~1.4.0"
   }
 }


### PR DESCRIPTION
This fixes issues with node 0.8.x and 0.9.x (and possibly others) which could not install verror with ^1.4.0
Node 0.10.x installs verror without issues.

An example where this error occurs is when installing the dependencies of node-dns on Travis with Node 0.9.x: https://travis-ci.org/tjfontaine/node-dns/jobs/38713208#L69
